### PR TITLE
Move GovLst & FixedGovLst onBehalf methods and permitAndStake methods into extensions

### DIFF
--- a/src/extensions/FixedGovLstOnBehalf.sol
+++ b/src/extensions/FixedGovLstOnBehalf.sol
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {FixedGovLst} from "src/FixedGovLst.sol";
+import {Staker} from "staker/Staker.sol";
+import {SignatureChecker} from "openzeppelin/utils/cryptography/SignatureChecker.sol";
+
+/// @title FixedGovLstOnBehalf
+/// @author [ScopeLift](https://scopelift.co)
+/// @notice This contract extension adds signature execution functionality to the FixedGovLstOnBehalf
+/// base contract, allowing key operations to be executed via signatures rather than requiring the
+/// owner or claimer to execute transactions directly. This includes staking, unstaking, converting to and from the
+/// rebasing LST, and altering the holder's delegatee via updating the LST owned deposit in which their tokens are
+/// held. Each operation requires a unique signature that is validated against the appropriate signer before
+/// execution.
+abstract contract FixedGovLstOnBehalf is FixedGovLst {
+  /// @notice Type hash used when encoding data for `updateDepositOnBehalf` calls.
+  bytes32 public constant UPDATE_DEPOSIT_TYPEHASH =
+    keccak256("UpdateDeposit(address account,uint256 depositId,uint256 nonce,uint256 deadline)");
+
+  /// @notice Type hash used when encoding data for `stakeOnBehalf` calls.
+  bytes32 public constant STAKE_TYPEHASH =
+    keccak256("Stake(address account,uint256 amount,uint256 nonce,uint256 deadline)");
+
+  /// @notice Type hash used when encoding data for `convertToFixedOnBehalf` calls.
+  bytes32 public constant CONVERT_TO_FIXED_TYPEHASH =
+    keccak256("ConvertToFixed(address account,uint256 amount,uint256 nonce,uint256 deadline)");
+
+  /// @notice Type hash used when encoding data for `convertToRebasingOnBehalf` calls.
+  bytes32 public constant CONVERT_TO_REBASING_TYPEHASH =
+    keccak256("ConvertToRebasing(address account,uint256 amount,uint256 nonce,uint256 deadline)");
+
+  /// @notice Type hash used when encoding data for `unstakeOnBehalf` calls.
+  bytes32 public constant UNSTAKE_TYPEHASH =
+    keccak256("Unstake(address account,uint256 amount,uint256 nonce,uint256 deadline)");
+
+  /// @notice Type hash used when encoding data for `rescueOnBehalf` calls.
+  bytes32 public constant RESCUE_TYPEHASH = keccak256("Rescue(address account,uint256 nonce,uint256 deadline)");
+
+  /// @notice Updates the deposit identifier for an account using a signed message for authorization. The deposit
+  /// identifier determines which delegatee receives the voting weight of the account's staked tokens.
+  /// @param _account The address of the account whose deposit identifier is being updated.
+  /// @param _newDepositId The new deposit identifier to associate with the account. Must be a deposit owned by the
+  /// rebasing LST. The underlying tokens staked in the fixed LST will be moved into this deposit.
+  /// @param _nonce The nonce being consumed by this operation to prevent replay attacks.
+  /// @param _deadline The timestamp after which the signature should expire.
+  /// @param _signature The signed message authorizing this deposit update, signed by the account.
+  function updateDepositOnBehalf(
+    address _account,
+    Staker.DepositIdentifier _newDepositId,
+    uint256 _nonce,
+    uint256 _deadline,
+    bytes memory _signature
+  ) external {
+    _validateSignature(
+      _account, Staker.DepositIdentifier.unwrap(_newDepositId), _nonce, _deadline, _signature, UPDATE_DEPOSIT_TYPEHASH
+    );
+    _updateDeposit(_account, _newDepositId);
+  }
+
+  /// @notice Stake tokens to receive fixed liquid stake tokens on behalf of a user, using a signature to validate the
+  /// user's intent. The staking address must pre-approve the LST contract to spend at least the would-be amount
+  /// of tokens.
+  /// @param _account The address on behalf of whom the staking is being performed.
+  /// @param _amount The quantity of tokens that will be staked.
+  /// @param _nonce The nonce being consumed by this operation.
+  /// @param _deadline The timestamp after which the signature should expire.
+  /// @param _signature Signature of the user authorizing this stake.
+  /// @dev The increase in the holder's balance after staking may be slightly less than the amount staked due to
+  /// rounding.
+  /// @return The amount of fixed tokens created after staking.
+  function stakeOnBehalf(address _account, uint256 _amount, uint256 _nonce, uint256 _deadline, bytes memory _signature)
+    external
+    returns (uint256)
+  {
+    _validateSignature(_account, _amount, _nonce, _deadline, _signature, STAKE_TYPEHASH);
+    return _stake(_account, _amount);
+  }
+
+  /// @notice Destroy liquid staked tokens, to receive the underlying token in exchange, on behalf of a user. Use a
+  /// signature to validate the user's  intent. Tokens are removed first from the default deposit, if any are present,
+  /// then from holder's specified deposit if any are needed.
+  /// @param _account The address on behalf of whom the unstaking is being performed.
+  /// @param _amount The amount of tokens to unstake.
+  /// @param _nonce The nonce being consumed by this operation.
+  /// @param _deadline The timestamp after which the signature should expire.
+  /// @param _signature Signature of the user authorizing this stake.
+  /// @return The amount of stake tokens created after unstaking.
+  function unstakeOnBehalf(
+    address _account,
+    uint256 _amount,
+    uint256 _nonce,
+    uint256 _deadline,
+    bytes memory _signature
+  ) external returns (uint256) {
+    _validateSignature(_account, _amount, _nonce, _deadline, _signature, UNSTAKE_TYPEHASH);
+    return _unstake(_account, _amount);
+  }
+
+  /// @notice Convert existing rebasing LST tokens to fixed balance LST tokens on behalf of an account.
+  /// @param _account The address on behalf of whom the conversion is being performed.
+  /// @param _amount The amount of rebasing LST tokens to convert.
+  /// @param _nonce The nonce being consumed by this operation.
+  /// @param _deadline The timestamp after which the signature should expire.
+  /// @param _signature Signature of the user authorizing this stake.
+  /// @return The amount of fixed tokens.
+  function convertToFixedOnBehalf(
+    address _account,
+    uint256 _amount,
+    uint256 _nonce,
+    uint256 _deadline,
+    bytes memory _signature
+  ) external returns (uint256) {
+    _validateSignature(_account, _amount, _nonce, _deadline, _signature, CONVERT_TO_FIXED_TYPEHASH);
+    return _convertToFixed(_account, _amount);
+  }
+
+  /// @notice Convert fixed LST tokens to rebasing LST tokens on behalf of an account.
+  /// @param _account The address on behalf of whom the conversion is being performed.
+  /// @param _amount The amount of fixed LST tokens to convert.
+  /// @param _nonce The nonce being consumed by this operation.
+  /// @param _deadline The timestamp after which the signature should expire.
+  /// @param _signature Signature of the user authorizing this stake.
+  /// @return The amount of rebasing tokens.
+  function convertToRebasingOnBehalf(
+    address _account,
+    uint256 _amount,
+    uint256 _nonce,
+    uint256 _deadline,
+    bytes memory _signature
+  ) external returns (uint256) {
+    _validateSignature(_account, _amount, _nonce, _deadline, _signature, CONVERT_TO_REBASING_TYPEHASH);
+    return _convertToRebasing(_account, _amount);
+  }
+
+  /// @notice Save rebasing LST tokens that were mistakenly sent to the fixed holder alias address on behalf of an
+  /// account.
+  /// @param _account The address on behalf of whom the rescue is being performed.
+  /// @param _nonce The nonce being consumed by this operation.
+  /// @param _deadline The timestamp after which the signature should expire.
+  /// @param _signature Signature of the user authorizing this stake.
+  /// @return The amount of fixed tokens rescued.
+  function rescueOnBehalf(address _account, uint256 _nonce, uint256 _deadline, bytes memory _signature)
+    external
+    returns (uint256)
+  {
+    _validateSignature(_account, _nonce, _deadline, _signature, RESCUE_TYPEHASH);
+    return _rescue(_account);
+  }
+
+  /// @notice Internal helper method which reverts with FixedGovLst__SignatureExpired if the signature
+  /// is invalid.
+  /// @param _account The address of the signer.
+  /// @param _amount The amount of tokens involved in this operation.
+  /// @param _nonce The nonce being consumed by this operation.
+  /// @param _deadline The timestamp after which the signature should expire.
+  /// @param _signature Signature of the user authorizing this stake.
+  /// @param _typeHash The typehash being signed over for this operation.
+  function _validateSignature(
+    address _account,
+    uint256 _amount,
+    uint256 _nonce,
+    uint256 _deadline,
+    bytes memory _signature,
+    bytes32 _typeHash
+  ) internal {
+    _useCheckedNonce(_account, _nonce);
+    if (block.timestamp > _deadline) {
+      revert FixedGovLst__SignatureExpired();
+    }
+    bytes32 _structHash = keccak256(abi.encode(_typeHash, _account, _amount, _nonce, _deadline));
+    bytes32 _hash = _hashTypedDataV4(_structHash);
+    if (!SignatureChecker.isValidSignatureNow(_account, _hash, _signature)) {
+      revert FixedGovLst__InvalidSignature();
+    }
+  }
+
+  /// @notice Internal helper method which reverts with FixedGovLst__SignatureExpired if the signature
+  /// is invalid.
+  /// @param _account The address of the signer.
+  /// @param _nonce The nonce being consumed by this operation.
+  /// @param _deadline The timestamp after which the signature should expire.
+  /// @param _signature Signature of the user authorizing this stake.
+  /// @param _typeHash The typehash being signed over for this operation.
+  function _validateSignature(
+    address _account,
+    uint256 _nonce,
+    uint256 _deadline,
+    bytes memory _signature,
+    bytes32 _typeHash
+  ) internal {
+    _useCheckedNonce(_account, _nonce);
+    if (block.timestamp > _deadline) {
+      revert FixedGovLst__SignatureExpired();
+    }
+    bytes32 _structHash = keccak256(abi.encode(_typeHash, _account, _nonce, _deadline));
+    bytes32 _hash = _hashTypedDataV4(_structHash);
+    if (!SignatureChecker.isValidSignatureNow(_account, _hash, _signature)) {
+      revert FixedGovLst__InvalidSignature();
+    }
+  }
+}

--- a/src/extensions/FixedGovLstPermitAndStake.sol
+++ b/src/extensions/FixedGovLstPermitAndStake.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {FixedGovLst} from "src/FixedGovLst.sol";
+import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
+
+/// @title FixedGovLstPermitAndStake
+/// @author [ScopeLift](https://scopelift.co)
+/// @notice This contract extension adds permit-based staking functionality to the FixedGovLst base contract,
+/// allowing token approvals to happen via signatures rather than requiring a separate transaction.
+/// The permit functionality is used in conjunction with the stake operation, improving UX by
+/// enabling users to approve and stake tokens in a single transaction. Note that this extension
+/// requires the stake token to support EIP-2612 permit functionality.
+abstract contract FixedGovLstPermitAndStake is FixedGovLst {
+  /// @notice Stake tokens to receive fixed liquid stake tokens. Before the staking operation occurs, a signature is
+  /// passed to the token contract's permit method to spend the would-be staked amount of the token.
+  /// @param _amount The quantity of fixed tokens that will be staked.
+  /// @param _deadline The timestamp after which the signature should expire.
+  /// @param _v ECDSA signature component: Parity of the `y` coordinate of point `R`
+  /// @param _r ECDSA signature component: x-coordinate of `R`
+  /// @param _s ECDSA signature component: `s` value of the signature
+  /// @return The number of fixed tokens after staking.
+  function permitAndStake(uint256 _amount, uint256 _deadline, uint8 _v, bytes32 _r, bytes32 _s)
+    public
+    returns (uint256)
+  {
+    try IERC20Permit(address(STAKE_TOKEN)).permit(msg.sender, address(this), _amount, _deadline, _v, _r, _s) {} catch {}
+    return stake(_amount);
+  }
+}

--- a/src/extensions/GovLstOnBehalf.sol
+++ b/src/extensions/GovLstOnBehalf.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {GovLst} from "src/GovLst.sol";
+import {Staker} from "staker/Staker.sol";
+import {SignatureChecker} from "openzeppelin/utils/cryptography/SignatureChecker.sol";
+
+/// @title GovLstOnBehalf
+/// @author [ScopeLift](https://scopelift.co)
+/// @notice This contract extension adds signature execution functionality to the GovLst
+/// base contract, allowing key operations to be executed via signatures rather than requiring the
+/// owner or claimer to execute transactions directly. This includes staking, unstaking,
+/// and altering the holder's delegatee via updating the LST owned deposit in which their tokens are held.
+/// Each operation requires a unique signature that is validated against the appropriate signer before
+/// execution.
+abstract contract GovLstOnBehalf is GovLst {
+  /// @notice Type hash used when encoding data for `stakeOnBehalf` calls.
+  bytes32 public constant STAKE_TYPEHASH =
+    keccak256("Stake(address account,uint256 amount,uint256 nonce,uint256 deadline)");
+
+  /// @notice Type hash used when encoding data for `unstakeOnBehalf` calls.
+  bytes32 public constant UNSTAKE_TYPEHASH =
+    keccak256("Unstake(address account,uint256 amount,uint256 nonce,uint256 deadline)");
+
+  /// @notice Type hash used when encoding data for `updateDepositOnBehalf` calls.
+  bytes32 public constant UPDATE_DEPOSIT_TYPEHASH =
+    keccak256("UpdateDeposit(address account,uint256 newDepositId,uint256 nonce,uint256 deadline)");
+
+  /// @notice Sets the deposit to which a holder is choosing to assign their staked tokens using a signature to
+  /// validate the user's intent.
+  /// @param _account The address of the holder whose deposit is being updated.
+  /// @param _newDepositId The stake deposit identifier to which this holder's staked tokens will be moved to and
+  /// kept in henceforth.
+  /// @param _nonce The nonce being consumed by this operation.
+  /// @param _deadline The timestamp after which the signature should expire.
+  /// @param _signature Signature of the user authorizing this stake.
+  /// @return _oldDepositId The stake deposit identifier which was previously assigned to this holder's staked.
+  function updateDepositOnBehalf(
+    address _account,
+    Staker.DepositIdentifier _newDepositId,
+    uint256 _nonce,
+    uint256 _deadline,
+    bytes memory _signature
+  ) external returns (Staker.DepositIdentifier _oldDepositId) {
+    _validateSignature(
+      _account, Staker.DepositIdentifier.unwrap(_newDepositId), _nonce, _deadline, _signature, UPDATE_DEPOSIT_TYPEHASH
+    );
+    _oldDepositId = _updateDeposit(_account, _newDepositId);
+    _emitDepositUpdatedEvent(_account, _oldDepositId, _newDepositId);
+  }
+
+  /// @notice Stake tokens to receive liquid stake tokens on behalf of a user, using a signature to validate the user's
+  /// intent. The staking address must pre-approve the LST contract to spend at least the would-be amount of tokens.
+  /// @param _account The address on behalf of whom the staking is being performed.
+  /// @param _amount The quantity of tokens that will be staked.
+  /// @param _nonce The nonce being consumed by this operation.
+  /// @param _deadline The timestamp after which the signature should expire.
+  /// @param _signature Signature of the user authorizing this stake.
+  /// @dev The increase in the holder's balance after staking may be slightly less than the amount staked due to
+  /// rounding.
+  /// @return The difference in LST token balance of the account after the stake operation.
+  function stakeOnBehalf(address _account, uint256 _amount, uint256 _nonce, uint256 _deadline, bytes memory _signature)
+    external
+    returns (uint256)
+  {
+    _validateSignature(_account, _amount, _nonce, _deadline, _signature, STAKE_TYPEHASH);
+    // UNI reverts on failure so it's not necessary to check return value.
+    STAKE_TOKEN.transferFrom(_account, address(this), _amount);
+    _emitStakedEvent(_account, _amount);
+    _emitTransferEvent(address(0), msg.sender, _amount);
+    return _stake(_account, _amount);
+  }
+
+  /// @notice Destroy liquid staked tokens, to receive the underlying token in exchange, on behalf of a user. Use a
+  /// signature to validate the user's  intent. Tokens are removed first from the default deposit, if any are present,
+  /// then from holder's specified deposit if any are needed.
+  /// @param _account The address on behalf of whom the unstaking is being performed.
+  /// @param _amount The amount of tokens to unstake.
+  /// @param _nonce The nonce being consumed by this operation.
+  /// @param _deadline The timestamp after which the signature should expire.
+  /// @param _signature Signature of the user authorizing this stake.
+  /// @return The amount of tokens that were withdrawn from the staking contract.
+  function unstakeOnBehalf(
+    address _account,
+    uint256 _amount,
+    uint256 _nonce,
+    uint256 _deadline,
+    bytes memory _signature
+  ) external returns (uint256) {
+    _validateSignature(_account, _amount, _nonce, _deadline, _signature, UNSTAKE_TYPEHASH);
+    _emitUnstakedEvent(_account, _amount);
+    _emitTransferEvent(msg.sender, address(0), _amount);
+    return _unstake(_account, _amount);
+  }
+
+  /// @notice Internal helper method which reverts with GovLst__SignatureExpired if the signature
+  /// is invalid.
+  /// @param _account The address of the signer.
+  /// @param _amount The amount of tokens involved in this operation.
+  /// @param _nonce The nonce being consumed by this operation.
+  /// @param _deadline The timestamp after which the signature should expire.
+  /// @param _signature Signature of the user authorizing this stake.
+  /// @param _typeHash The typehash being signed over for this operation.
+  function _validateSignature(
+    address _account,
+    uint256 _amount,
+    uint256 _nonce,
+    uint256 _deadline,
+    bytes memory _signature,
+    bytes32 _typeHash
+  ) internal {
+    _useCheckedNonce(_account, _nonce);
+    if (block.timestamp > _deadline) {
+      revert GovLst__SignatureExpired();
+    }
+    bytes32 _structHash = keccak256(abi.encode(_typeHash, _account, _amount, _nonce, _deadline));
+    bytes32 _hash = _hashTypedDataV4(_structHash);
+    if (!SignatureChecker.isValidSignatureNow(_account, _hash, _signature)) {
+      revert GovLst__InvalidSignature();
+    }
+  }
+}

--- a/src/extensions/GovLstPermitAndStake.sol
+++ b/src/extensions/GovLstPermitAndStake.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {GovLst} from "src/GovLst.sol";
+import {IERC20Permit} from "openzeppelin/token/ERC20/extensions/IERC20Permit.sol";
+
+/// @title GovLstPermitAndStake
+/// @author [ScopeLift](https://scopelift.co)
+/// @notice This contract extension adds permit-based staking functionality to the GovLst base contract,
+/// allowing token approvals to happen via signatures rather than requiring a separate transaction.
+/// The permit functionality is used in conjunction with the stake operation, improving UX by
+/// enabling users to approve and stake tokens in a single transaction. Note that this extension
+/// requires the stake token to support EIP-2612 permit functionality.
+abstract contract GovLstPermitAndStake is GovLst {
+  /// @notice Stake tokens to receive liquid stake tokens. Before the staking operation occurs, a signature is passed
+  /// to the token contract's permit method to spend the would-be staked amount of the token.
+  /// @param _amount The quantity of tokens that will be staked.
+  /// @param _deadline The timestamp after which the signature should expire.
+  /// @param _v ECDSA signature component: Parity of the `y` coordinate of point `R`
+  /// @param _r ECDSA signature component: x-coordinate of `R`
+  /// @param _s ECDSA signature component: `s` value of the signature
+  /// @return The difference in LST token balance of the msg.sender.
+  function permitAndStake(uint256 _amount, uint256 _deadline, uint8 _v, bytes32 _r, bytes32 _s)
+    external
+    returns (uint256)
+  {
+    try IERC20Permit(address(STAKE_TOKEN)).permit(msg.sender, address(this), _amount, _deadline, _v, _r, _s) {} catch {}
+    // UNI reverts on failure so it's not necessary to check return value.
+    STAKE_TOKEN.transferFrom(msg.sender, address(this), _amount);
+    _emitStakedEvent(msg.sender, _amount);
+    _emitTransferEvent(address(0), msg.sender, _amount);
+    return _stake(msg.sender, _amount);
+  }
+}

--- a/test/FixedGovLst.t.sol
+++ b/test/FixedGovLst.t.sol
@@ -5,6 +5,7 @@ import {console2, stdStorage, StdStorage, stdError, Vm} from "forge-std/Test.sol
 import {GovLstTest} from "test/GovLst.t.sol";
 import {Staker} from "staker/Staker.sol";
 import {FixedGovLst} from "src/FixedGovLst.sol";
+import {FixedGovLstHarness} from "test/harnesses/FixedGovLstHarness.sol";
 import {FixedLstAddressAlias} from "src/FixedLstAddressAlias.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {ERC20Votes} from "openzeppelin/token/ERC20/extensions/ERC20Votes.sol";
@@ -15,11 +16,11 @@ import {IERC20Errors} from "openzeppelin/interfaces/draft-IERC6093.sol";
 using FixedLstAddressAlias for address;
 
 contract FixedGovLstTest is GovLstTest {
-  FixedGovLst fixedLst;
+  FixedGovLstHarness fixedLst;
 
   function setUp() public virtual override {
     super.setUp();
-    fixedLst = lst.FIXED_LST();
+    fixedLst = FixedGovLstHarness(address(lst.FIXED_LST()));
   }
 
   function _updateFixedDelegatee(address _holder, address _delegatee) internal {
@@ -111,7 +112,9 @@ contract FixedGovLstTest is GovLstTest {
     uint256 _signerPrivateKey
   ) internal view returns (bytes memory) {
     bytes32 structHash = keccak256(abi.encode(_typehash, _account, _amount, _nonce, _expiry));
-    bytes32 hash = _hashTypedDataV4(EIP712_DOMAIN_TYPEHASH, structHash, "FixedGovLst", "1", address(fixedLst));
+    bytes32 hash = _hashTypedDataV4(
+      EIP712_DOMAIN_TYPEHASH, structHash, bytes(fixedLst.name()), bytes(fixedLst.version()), address(fixedLst)
+    );
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(_signerPrivateKey, hash);
     return abi.encodePacked(r, s, v);
   }
@@ -124,7 +127,9 @@ contract FixedGovLstTest is GovLstTest {
     uint256 _signerPrivateKey
   ) internal view returns (bytes memory) {
     bytes32 structHash = keccak256(abi.encode(_typehash, _account, _nonce, _expiry));
-    bytes32 hash = _hashTypedDataV4(EIP712_DOMAIN_TYPEHASH, structHash, "FixedGovLst", "1", address(fixedLst));
+    bytes32 hash = _hashTypedDataV4(
+      EIP712_DOMAIN_TYPEHASH, structHash, bytes(fixedLst.name()), bytes(fixedLst.version()), address(fixedLst)
+    );
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(_signerPrivateKey, hash);
     return abi.encodePacked(r, s, v);
   }
@@ -313,7 +318,10 @@ contract Permit is FixedGovLstTest {
     uint256 _nonce = ERC20Permit(address(fixedLst)).nonces(_owner);
     bytes32 structHash = _buildPermitStructHash(_owner, _spender, _value, _nonce, _deadline);
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(
-      _ownerPrivateKey, _hashTypedDataV4(EIP712_DOMAIN_TYPEHASH, structHash, "FixedGovLst", "1", address(fixedLst))
+      _ownerPrivateKey,
+      _hashTypedDataV4(
+        EIP712_DOMAIN_TYPEHASH, structHash, bytes(fixedLst.name()), bytes(fixedLst.version()), address(fixedLst)
+      )
     );
 
     assertEq(fixedLst.allowance(_owner, _spender), 0);
@@ -341,7 +349,10 @@ contract Permit is FixedGovLstTest {
     uint256 _nonce = ERC20Permit(address(fixedLst)).nonces(_owner);
     bytes32 structHash = _buildPermitStructHash(_owner, _spender, _value, _nonce, _deadline);
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(
-      _ownerPrivateKey, _hashTypedDataV4(EIP712_DOMAIN_TYPEHASH, structHash, "FixedGovLst", "1", address(fixedLst))
+      _ownerPrivateKey,
+      _hashTypedDataV4(
+        EIP712_DOMAIN_TYPEHASH, structHash, bytes(fixedLst.name()), bytes(fixedLst.version()), address(fixedLst)
+      )
     );
 
     vm.prank(_sender);
@@ -373,7 +384,10 @@ contract Permit is FixedGovLstTest {
     uint256 _nonce = ERC20Permit(address(fixedLst)).nonces(_owner);
     bytes32 structHash = _buildPermitStructHash(_owner, _spender, _value, _nonce, _deadline);
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(
-      _ownerPrivateKey, _hashTypedDataV4(EIP712_DOMAIN_TYPEHASH, structHash, "FixedGovLst", "1", address(fixedLst))
+      _ownerPrivateKey,
+      _hashTypedDataV4(
+        EIP712_DOMAIN_TYPEHASH, structHash, bytes(fixedLst.name()), bytes(fixedLst.version()), address(fixedLst)
+      )
     );
 
     vm.prank(_sender);
@@ -400,7 +414,10 @@ contract Permit is FixedGovLstTest {
     uint256 _nonce = ERC20Permit(address(fixedLst)).nonces(_owner);
     bytes32 structHash = _buildPermitStructHash(_owner, _spender, _value, _nonce, _deadline);
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(
-      _wrongPrivateKey, _hashTypedDataV4(EIP712_DOMAIN_TYPEHASH, structHash, "FixedGovLst", "1", address(fixedLst))
+      _wrongPrivateKey,
+      _hashTypedDataV4(
+        EIP712_DOMAIN_TYPEHASH, structHash, bytes(fixedLst.name()), bytes(fixedLst.version()), address(fixedLst)
+      )
     );
 
     vm.prank(_sender);
@@ -424,7 +441,10 @@ contract Permit is FixedGovLstTest {
     uint256 _nonce = ERC20Permit(address(fixedLst)).nonces(_owner);
     bytes32 structHash = _buildPermitStructHash(_owner, _spender, _value, _nonce, _deadline);
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(
-      _ownerPrivateKey, _hashTypedDataV4(EIP712_DOMAIN_TYPEHASH, structHash, "FixedGovLst", "1", address(fixedLst))
+      _ownerPrivateKey,
+      _hashTypedDataV4(
+        EIP712_DOMAIN_TYPEHASH, structHash, bytes(fixedLst.name()), bytes(fixedLst.version()), address(fixedLst)
+      )
     );
 
     vm.prank(_sender);

--- a/test/harnesses/FixedGovLstHarness.sol
+++ b/test/harnesses/FixedGovLstHarness.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {FixedGovLst} from "src/FixedGovLst.sol";
+import {FixedGovLstOnBehalf} from "src/extensions/FixedGovLstOnBehalf.sol";
+import {FixedGovLstPermitAndStake} from "src/extensions/FixedGovLstPermitAndStake.sol";
+import {GovLst} from "src/GovLst.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract FixedGovLstHarness is FixedGovLstOnBehalf, FixedGovLstPermitAndStake {
+  constructor(
+    string memory _name,
+    string memory _symbol,
+    string memory _version,
+    GovLst _lst,
+    IERC20 _stakeToken,
+    uint256 _shareScaleFactor
+  ) FixedGovLst(_name, _symbol, _version, _lst, _stakeToken, _shareScaleFactor) {}
+}

--- a/test/harnesses/GovLstHarness.sol
+++ b/test/harnesses/GovLstHarness.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {GovLst} from "src/GovLst.sol";
+import {GovLstOnBehalf} from "src/extensions/GovLstOnBehalf.sol";
+import {GovLstPermitAndStake} from "src/extensions/GovLstPermitAndStake.sol";
+import {FixedGovLst} from "src/FixedGovLst.sol";
+import {Staker} from "staker/Staker.sol";
+import {FixedGovLstHarness} from "test/harnesses/FixedGovLstHarness.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract GovLstHarness is GovLst, GovLstOnBehalf, GovLstPermitAndStake {
+  constructor(
+    string memory _name,
+    string memory _symbol,
+    Staker _staker,
+    address _initialDefaultDelegatee,
+    address _initialOwner,
+    uint80 _initialPayoutAmount,
+    address _initialDelegateeGuardian,
+    uint256 _stakeToBurn
+  )
+    GovLst(
+      _name,
+      _symbol,
+      "2",
+      _staker,
+      _initialDefaultDelegatee,
+      _initialOwner,
+      _initialPayoutAmount,
+      _initialDelegateeGuardian,
+      _stakeToBurn
+    )
+  {}
+
+  function _deployFixedGovLst(
+    string memory _name,
+    string memory _symbol,
+    string memory _version,
+    GovLst _lst,
+    IERC20 _stakeToken,
+    uint256 _shareScaleFactor
+  ) internal virtual override returns (FixedGovLst _fixedLst) {
+    return new FixedGovLstHarness(_name, _symbol, _version, _lst, _stakeToken, _shareScaleFactor);
+  }
+}

--- a/test/invariant/GovLst.invariants.t.sol
+++ b/test/invariant/GovLst.invariants.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.28;
 import {Test, console2} from "forge-std/Test.sol";
 import {GovLst} from "src/GovLst.sol";
 import {GovLstHandler} from "./GovLst.handler.sol";
+import {GovLstHarness} from "test/harnesses/GovLstHarness.sol";
 import {UnitTestBase} from "test/UnitTestBase.sol";
 import {Staker} from "staker/Staker.sol";
 import {MockFullEarningPowerCalculator} from "test/mocks/MockFullEarningPowerCalculator.sol";
@@ -55,7 +56,9 @@ contract GovStakerInvariants is Test, UnitTestBase {
     staker.setRewardNotifier(stakerAdmin, true);
 
     // Finally, deploy the lst for tests.
-    lst = new GovLst("Gov Lst", "stGov", staker, defaultDelegatee, lstOwner, initialPayoutAmount, delegateeGuardian, 0);
+    lst = new GovLstHarness(
+      "Gov Lst", "stGov", staker, defaultDelegatee, lstOwner, initialPayoutAmount, delegateeGuardian, 0
+    );
 
     // Set the withdrawal delay to a non-zero amount
     vm.startPrank(lstOwner);


### PR DESCRIPTION
Both the rebasing and fixed LST contracts can now be assembled with optional usage of
the onBehalf methods and the permitAndStake methods. In the process of extracting this
functionality into extensions, several other changes were made:

* Deployment of the FixedGovLst contract inside the GovLst constructor is now done by a
      virtual method. This method must be implemented by a concrete implementation of GovLst
      which must deploy a concrete implementation of a FixedGovLst
* The EIP712 "version" parameter is now accepted as a constructor parameter for the GovLst
      and is passed to the FixedGovLst during deployment to ensure they match.
* The ERC20 name() parameter and the name parameter used in calculating the EIP712 hash are
      now ensured to be the same on both versions of the LST, where the rebasing LST has the
      "Rebasing " prefix in both cases.
* View methods have been added to ensure the EIP712 version, nonces, and DOMAIN_SEPARATOR
      methods are exposed on both the rebasing and fixed LSTs.
* The FixedGovLst contract now conforms to the IERC20Permit interface

closes #9 