### PR TITLE
Fix broken gas report scenarios and re-run reports

### DIFF
--- a/test/gas-reports/FixedGovLst.g.sol
+++ b/test/gas-reports/FixedGovLst.g.sol
@@ -1147,6 +1147,12 @@ contract FixedGovLstGasReport is FixedGovLstTest, GasReport {
       _delegatee = makeScenarioAddr("Delegatee");
       _staker = makeScenarioAddr("Staker");
       _depositId = lst.fetchOrInitializeDepositForDelegatee(_delegatee);
+
+      // Someone else must stake first so the deposit isn't empty
+      address _firstStaker = makeScenarioAddr("First Staker");
+      _stakeAmount = 100e18;
+      _stakeOnDelegateeFixedDeposit(_depositId, _firstStaker);
+
       vm.prank(_staker);
       fixedLst.updateDeposit(_depositId);
       recordScenarioGasResult();
@@ -1160,6 +1166,11 @@ contract FixedGovLstGasReport is FixedGovLstTest, GasReport {
       _updateFixedDelegatee(_staker, _delegatee);
       _delegatee = makeScenarioAddr("Updated Delegatee");
       _depositId = lst.fetchOrInitializeDepositForDelegatee(_delegatee);
+
+      // Someone else must stake first so the deposit isn't empty
+      address _firstStaker = makeScenarioAddr("First Staker");
+      _stakeAmount = 100e18;
+      _stakeOnDelegateeFixedDeposit(_depositId, _firstStaker);
 
       vm.prank(_staker);
       fixedLst.updateDeposit(_depositId);

--- a/test/gas-reports/GovLst.g.sol
+++ b/test/gas-reports/GovLst.g.sol
@@ -1193,6 +1193,12 @@ contract GovLstGasReport is GovLstTest, GasReport {
       _delegatee = makeScenarioAddr("Delegatee");
       _staker = makeScenarioAddr("Staker");
       _depositId = lst.fetchOrInitializeDepositForDelegatee(_delegatee);
+
+      // Someone else must stake first so the deposit isn't empty
+      address _firstStaker = makeScenarioAddr("First Staker");
+      _stakeAmount = 100e18;
+      _stakeOnDelegateeDeposit(_depositId, _firstStaker);
+
       vm.prank(_staker);
       lst.updateDeposit(_depositId);
       recordScenarioGasResult();
@@ -1206,6 +1212,11 @@ contract GovLstGasReport is GovLstTest, GasReport {
       _updateDelegatee(_staker, _delegatee);
       _delegatee = makeScenarioAddr("Updated Delegatee");
       _depositId = lst.fetchOrInitializeDepositForDelegatee(_delegatee);
+
+      // Someone else must stake first so the deposit isn't empty
+      address _firstStaker = makeScenarioAddr("First Staker");
+      _stakeAmount = 100e18;
+      _stakeOnDelegateeDeposit(_depositId, _firstStaker);
 
       vm.prank(_staker);
       lst.updateDeposit(_depositId);

--- a/test/gas-reports/fixedLst-gas-report.json
+++ b/test/gas-reports/fixedLst-gas-report.json
@@ -1,26 +1,26 @@
 {
-  "generatedAt": 1740059055,
+  "generatedAt": 1742565085,
   "reportName:": "fixedLstGasReport",
   "results": [
     {
       "scenarioName": "First Stake to Default Delegate",
-      "gasUsed": 199520
+      "gasUsed": 200238
     },
     {
       "scenarioName": "Second Stake To Default Delegatee",
-      "gasUsed": 165639
+      "gasUsed": 166357
     },
     {
       "scenarioName": "First Stake After Updating To A New Delegatee",
-      "gasUsed": 236650
+      "gasUsed": 200925
     },
     {
       "scenarioName": "First Stake After Updating To An Existing LST Delegatee",
-      "gasUsed": 183107
+      "gasUsed": 183825
     },
     {
       "scenarioName": "Second Stake To A Custom Delegatee",
-      "gasUsed": 166326
+      "gasUsed": 167044
     },
     {
       "scenarioName": "Sender With Default Delegatee Transfers Balance To New Receiver With Default Delegatee",
@@ -88,151 +88,151 @@
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Balance To a New Receiver With Default Delegatee",
-      "gasUsed": 84700
+      "gasUsed": 84678
     },
     {
       "scenarioName": "Sender With Default Delegatee Max Approves Caller To Transfer Balance To a New Receiver With Default Delegatee",
-      "gasUsed": 84700
+      "gasUsed": 84678
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Default Delegatee",
-      "gasUsed": 99419
+      "gasUsed": 99397
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 51454
+      "gasUsed": 51432
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 65538
+      "gasUsed": 65516
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To New Receiver With Default Delegatee",
-      "gasUsed": 234893
+      "gasUsed": 234871
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Default Delegatee",
-      "gasUsed": 249931
+      "gasUsed": 249909
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 201012
+      "gasUsed": 200990
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 216050
+      "gasUsed": 216028
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To New Receiver With Same Delegatee",
-      "gasUsed": 73312
+      "gasUsed": 73290
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Same Delegatee",
-      "gasUsed": 83550
+      "gasUsed": 83528
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To Existing Receiver With Same Delegatee",
-      "gasUsed": 56531
+      "gasUsed": 56509
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Same Delegatee",
-      "gasUsed": 66757
+      "gasUsed": 66735
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To New Receiver With Custom Delegatee",
-      "gasUsed": 271393
+      "gasUsed": 234928
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Custom Delegatee",
-      "gasUsed": 286431
+      "gasUsed": 249966
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To Existing Receiver With Custom Delegatee",
-      "gasUsed": 201069
+      "gasUsed": 201047
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Custom Delegatee",
-      "gasUsed": 216107
+      "gasUsed": 216085
     },
     {
       "scenarioName": "Unstake Full Balance From The Default Delegatee",
-      "gasUsed": 226652
+      "gasUsed": 227420
     },
     {
       "scenarioName": "Unstake Partial Balance From The Default Delegatee",
-      "gasUsed": 236595
+      "gasUsed": 237363
     },
     {
       "scenarioName": "Unstake Full Balance From Unique Custom Delegatee",
-      "gasUsed": 312514
+      "gasUsed": 313128
     },
     {
       "scenarioName": "Unstake Partial Balance From Unique Custom Delegatee",
-      "gasUsed": 313044
+      "gasUsed": 313658
     },
     {
       "scenarioName": "Unstake Full Balance From a Non-Unique Custom Delegatee",
-      "gasUsed": 312514
+      "gasUsed": 313128
     },
     {
       "scenarioName": "Unstake Partial Balance From a Non-Unique Custom Delegatee",
-      "gasUsed": 313044
+      "gasUsed": 313658
     },
     {
       "scenarioName": "Unstake Full Balance From The Default Delegatee After Rewards",
-      "gasUsed": 231923
+      "gasUsed": 232691
     },
     {
       "scenarioName": "Unstake Partial Balance From The Default Delegatee After Rewards",
-      "gasUsed": 236747
+      "gasUsed": 237515
     },
     {
       "scenarioName": "Unstake Full Balance From Unique Custom Delegatee After Rewards",
-      "gasUsed": 365780
+      "gasUsed": 366548
     },
     {
       "scenarioName": "Unstake Partial Balance From Unique Custom Delegatee After Rewards",
-      "gasUsed": 365792
+      "gasUsed": 366560
     },
     {
       "scenarioName": "Unstake Full Balance From a Non-Unique Custom Delegatee After Rewards",
-      "gasUsed": 365792
+      "gasUsed": 366560
     },
     {
       "scenarioName": "Unstake Partial Balance From a Non-Unique Custom Delegatee After Rewards",
-      "gasUsed": 365792
+      "gasUsed": 366560
     },
     {
       "scenarioName": "Unstake Earned Rewards Only From The Default Delegatee After Rewards",
-      "gasUsed": 293489
+      "gasUsed": 294104
     },
     {
       "scenarioName": "Unstake Earned Rewards Only From Unique Custom Delegatee After Rewards",
-      "gasUsed": 293489
+      "gasUsed": 294104
     },
     {
       "scenarioName": "Updating from default deposit with nothing staked",
-      "gasUsed": 66678
+      "gasUsed": 73457
     },
     {
       "scenarioName": "Updating from custom deposit with nothing staked",
-      "gasUsed": 49580
+      "gasUsed": 56359
     },
     {
       "scenarioName": "Updating from default deposit after staking",
-      "gasUsed": 238224
+      "gasUsed": 246987
     },
     {
       "scenarioName": "Updating from custom deposit after staking",
-      "gasUsed": 233427
+      "gasUsed": 247001
     },
     {
       "scenarioName": "Updating from default deposit after staking and earning rewards",
-      "gasUsed": 238224
+      "gasUsed": 246987
     },
     {
       "scenarioName": "Updating from custom deposit after staking and earning rewards",
-      "gasUsed": 313863
+      "gasUsed": 327437
     },
     {
       "scenarioName": "Convert rebasing to fixed with a default delegatee and the full amount",
@@ -244,7 +244,7 @@
     },
     {
       "scenarioName": "Convert rebasing to fixed with a custom delegatee and the full amount",
-      "gasUsed": 245258
+      "gasUsed": 240458
     },
     {
       "scenarioName": "Convert rebasing to fixed with a custom delegatee and the partial amount",
@@ -252,23 +252,23 @@
     },
     {
       "scenarioName": "Convert fixed to rebasing with a default delegatee and the full amount",
-      "gasUsed": 77540
+      "gasUsed": 77518
     },
     {
       "scenarioName": "Convert fixed to rebasing with a default delegatee and the partial amount",
-      "gasUsed": 77540
+      "gasUsed": 77518
     },
     {
       "scenarioName": "Convert fixed to rebasing with a custom delegatee and the full amount",
-      "gasUsed": 228055
+      "gasUsed": 228033
     },
     {
       "scenarioName": "Convert fixed to rebasing with a custom delegatee and the partial amount",
-      "gasUsed": 228055
+      "gasUsed": 228033
     },
     {
       "scenarioName": "Rescue funds sent to alias address",
-      "gasUsed": 61444
+      "gasUsed": 61532
     }
   ]
 }

--- a/test/gas-reports/lst-gas-report.json
+++ b/test/gas-reports/lst-gas-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": 1740059045,
+  "generatedAt": 1742565080,
   "reportName:": "lstGasReport",
   "results": [
     {
@@ -12,23 +12,23 @@
     },
     {
       "scenarioName": "First Stake to Default Delegate",
-      "gasUsed": 164621
+      "gasUsed": 165339
     },
     {
       "scenarioName": "Second Stake To Default Delegatee",
-      "gasUsed": 147840
+      "gasUsed": 148558
     },
     {
       "scenarioName": "First Stake After Updating To A New Delegatee",
-      "gasUsed": 201751
+      "gasUsed": 166026
     },
     {
       "scenarioName": "First Stake After Updating To An Existing LST Delegatee",
-      "gasUsed": 148208
+      "gasUsed": 148926
     },
     {
       "scenarioName": "Second Stake To A Custom Delegatee",
-      "gasUsed": 148527
+      "gasUsed": 149245
     },
     {
       "scenarioName": "Sender With Default Delegatee Transfers Balance To New Receiver With Default Delegatee",
@@ -80,11 +80,11 @@
     },
     {
       "scenarioName": "Sender With Custom Delegatee Transfers Balance To New Receiver With Custom Delegatee",
-      "gasUsed": 241661
+      "gasUsed": 205218
     },
     {
       "scenarioName": "Sender With Custom Delegatee Transfers Partial Balance To New Receiver With Custom Delegatee",
-      "gasUsed": 247099
+      "gasUsed": 210656
     },
     {
       "scenarioName": "Sender With Custom Delegatee Transfers Balance To Existing Receiver With Custom Delegatee",
@@ -96,159 +96,159 @@
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Balance To a New Receiver With Default Delegatee",
-      "gasUsed": 56113
+      "gasUsed": 56090
     },
     {
       "scenarioName": "Sender With Default Delegatee Max Approves Caller To Transfer Balance To a New Receiver With Default Delegatee",
-      "gasUsed": 57778
+      "gasUsed": 57756
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Default Delegatee",
-      "gasUsed": 66032
+      "gasUsed": 66009
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 39332
+      "gasUsed": 39309
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 49251
+      "gasUsed": 49228
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To New Receiver With Default Delegatee",
-      "gasUsed": 206309
+      "gasUsed": 206286
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Default Delegatee",
-      "gasUsed": 216547
+      "gasUsed": 216524
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 189528
+      "gasUsed": 189505
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 199766
+      "gasUsed": 199743
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To New Receiver With Same Delegatee",
-      "gasUsed": 44725
+      "gasUsed": 44702
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Same Delegatee",
-      "gasUsed": 50163
+      "gasUsed": 50140
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To Existing Receiver With Same Delegatee",
-      "gasUsed": 45044
+      "gasUsed": 45021
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Same Delegatee",
-      "gasUsed": 50470
+      "gasUsed": 50447
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To New Receiver With Custom Delegatee",
-      "gasUsed": 242809
+      "gasUsed": 206343
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Custom Delegatee",
-      "gasUsed": 253047
+      "gasUsed": 216581
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To Existing Receiver With Custom Delegatee",
-      "gasUsed": 189585
+      "gasUsed": 189562
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Custom Delegatee",
-      "gasUsed": 199823
+      "gasUsed": 199800
     },
     {
       "scenarioName": "Unstake Full Balance From The Default Delegatee",
-      "gasUsed": 204421
+      "gasUsed": 205298
     },
     {
       "scenarioName": "Unstake Partial Balance From The Default Delegatee",
-      "gasUsed": 209551
+      "gasUsed": 210428
     },
     {
       "scenarioName": "Unstake Full Balance From Unique Custom Delegatee",
-      "gasUsed": 204728
+      "gasUsed": 205605
     },
     {
       "scenarioName": "Unstake Partial Balance From Unique Custom Delegatee",
-      "gasUsed": 209871
+      "gasUsed": 210748
     },
     {
       "scenarioName": "Unstake Full Balance From a Non-Unique Custom Delegatee",
-      "gasUsed": 209528
+      "gasUsed": 210405
     },
     {
       "scenarioName": "Unstake Partial Balance From a Non-Unique Custom Delegatee",
-      "gasUsed": 209871
+      "gasUsed": 210748
     },
     {
       "scenarioName": "Unstake Full Balance From The Default Delegatee After Rewards",
-      "gasUsed": 209640
+      "gasUsed": 210517
     },
     {
       "scenarioName": "Unstake Partial Balance From The Default Delegatee After Rewards",
-      "gasUsed": 209627
+      "gasUsed": 210504
     },
     {
       "scenarioName": "Unstake Full Balance From Unique Custom Delegatee After Rewards",
-      "gasUsed": 267683
+      "gasUsed": 263760
     },
     {
       "scenarioName": "Unstake Partial Balance From Unique Custom Delegatee After Rewards",
-      "gasUsed": 267683
+      "gasUsed": 268560
     },
     {
       "scenarioName": "Unstake Full Balance From a Non-Unique Custom Delegatee After Rewards",
-      "gasUsed": 267683
+      "gasUsed": 268560
     },
     {
       "scenarioName": "Unstake Partial Balance From a Non-Unique Custom Delegatee After Rewards",
-      "gasUsed": 267683
+      "gasUsed": 268560
     },
     {
       "scenarioName": "Unstake Earned Rewards Only From The Default Delegatee After Rewards",
-      "gasUsed": 209531
+      "gasUsed": 210408
     },
     {
       "scenarioName": "Unstake Earned Rewards Only From Unique Custom Delegatee After Rewards",
-      "gasUsed": 209531
+      "gasUsed": 210408
     },
     {
       "scenarioName": "Claim and distribute a reward",
-      "gasUsed": 193932
+      "gasUsed": 195212
     },
     {
       "scenarioName": "Claim and distribute a reward that includes a fee",
-      "gasUsed": 192008
+      "gasUsed": 193287
     },
     {
       "scenarioName": "Updating from default deposit with nothing staked",
-      "gasUsed": 63221
+      "gasUsed": 70022
     },
     {
       "scenarioName": "Updating from custom deposit with nothing staked",
-      "gasUsed": 46123
+      "gasUsed": 52924
     },
     {
       "scenarioName": "Updating from default deposit after staking",
-      "gasUsed": 234764
+      "gasUsed": 243552
     },
     {
       "scenarioName": "Updating from custom deposit after staking",
-      "gasUsed": 234767
+      "gasUsed": 238766
     },
     {
       "scenarioName": "Updating from default deposit after staking and earning rewards",
-      "gasUsed": 234764
+      "gasUsed": 243552
     },
     {
       "scenarioName": "Updating from custom deposit after staking and earning rewards",
-      "gasUsed": 292503
+      "gasUsed": 296502
     }
   ]
 }


### PR DESCRIPTION
The reports were broken because we made it invalid to update to a deposit with a global zero balance.