### PR TITLE
[Catina #68] Wrong Timepoint Used For Quorum Check In AutoDelegate

### DIFF
--- a/src/auto-delegates/extensions/AutoDelegateOpenZeppelinGovernor.sol
+++ b/src/auto-delegates/extensions/AutoDelegateOpenZeppelinGovernor.sol
@@ -43,7 +43,8 @@ abstract contract AutoDelegateOpenZeppelinGovernor {
     returns (uint256 _proposalDeadline, uint256 _forVotes, uint256 _againstVotes, uint256 _quorumVotes)
   {
     _proposalDeadline = IGovernor(_governor).proposalDeadline(_proposalId);
+    uint256 _proposalSnapshot = IGovernor(_governor).proposalSnapshot(_proposalId);
     (_againstVotes, _forVotes,) = IGovernorCountingExtensions(_governor).proposalVotes(_proposalId);
-    _quorumVotes = IGovernor(_governor).quorum(clock());
+    _quorumVotes = IGovernor(_governor).quorum(_proposalSnapshot);
   }
 }


### PR DESCRIPTION
#### Description

- Use proposal start for quorum rather than current clock.

Closes #70 