### PR TITLE
Correct & cleanup view methods related to reading a holder's delegatee

### DIFF
--- a/src/FixedGovLst.sol
+++ b/src/FixedGovLst.sol
@@ -194,6 +194,26 @@ contract FixedGovLst is IERC20, IERC20Metadata, IERC20Permit, Multicall, EIP712,
     return LST.depositForDelegatee(_delegatee);
   }
 
+  /// @notice The delegatee to whom a given holder's stake is currently delegated. This will be the delegatee to whom
+  /// the user has chosen to assign their voting weight OR the default delegatee, if the user's deposit has been
+  /// moved to the override state.
+  /// @param _holder The holder in question.
+  /// @return _delegatee The address to which this holder's voting weight is currently delegated.
+  function delegateeForHolder(address _holder) public view virtual returns (address _delegatee) {
+    return LST.delegateeForHolder(_holder.fixedAlias());
+  }
+
+  /// @notice The delegatee to whom a given holder's stake is currently delegated. This will be the delegatee to whom
+  /// the user has chosen to assign their voting weight OR the default delegatee, if the user's deposit has been
+  /// moved to the override state.
+  /// @param _holder The holder in question.
+  /// @return The address to which this holder's voting weight is currently delegated.
+  /// @dev This method is included for partial compatibility with the `IVotes` interface. It returns the same data as
+  /// the `delegateeForHolder` method.
+  function delegates(address _holder) external view virtual returns (address) {
+    return LST.delegateeForHolder(_holder.fixedAlias());
+  }
+
   /// @notice Returns the deposit identifier managed by the LST for a given delegatee. If that deposit does not yet
   /// exist, it initializes it. A depositor can call this method if the deposit for their chosen delegatee has not been
   /// previously initialized.
@@ -271,13 +291,12 @@ contract FixedGovLst is IERC20, IERC20Metadata, IERC20Permit, Multicall, EIP712,
 
   /// @notice Allow a depositor to change the address they are delegating their staked tokens.
   /// @param _delegatee The address where voting is delegated.
+  /// @dev This operation can be completed in a more gas efficient manner by calling `updateDeposit` with the depositId
+  /// of the user's chosen delegatee, assuming it has already been initialized. This method is included primarily for
+  /// partial compatibility with the `IVotes` interface.
   function delegate(address _delegatee) public virtual {
     Staker.DepositIdentifier _depositId = LST.fetchOrInitializeDepositForDelegatee(_delegatee);
     updateDeposit(_depositId);
-  }
-
-  function delegates(address _holder) external virtual returns (address) {
-    return LST.delegateeForHolder(_holder.fixedAlias());
   }
 
   /// @notice Save rebasing LST tokens that were mistakenly sent to the fixed holder alias address. Each fixed LST

--- a/test/gas-reports/fixedLst-gas-report.json
+++ b/test/gas-reports/fixedLst-gas-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": 1743447557,
+  "generatedAt": 1744648393,
   "reportName:": "fixedLstGasReport",
   "results": [
     {
@@ -88,127 +88,127 @@
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Balance To a New Receiver With Default Delegatee",
-      "gasUsed": 86077
+      "gasUsed": 86055
     },
     {
       "scenarioName": "Sender With Default Delegatee Max Approves Caller To Transfer Balance To a New Receiver With Default Delegatee",
-      "gasUsed": 86077
+      "gasUsed": 86055
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Default Delegatee",
-      "gasUsed": 100796
+      "gasUsed": 100774
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 52831
+      "gasUsed": 52809
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 66915
+      "gasUsed": 66893
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To New Receiver With Default Delegatee",
-      "gasUsed": 236231
+      "gasUsed": 236209
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Default Delegatee",
-      "gasUsed": 251269
+      "gasUsed": 251247
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 202350
+      "gasUsed": 202328
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 217388
+      "gasUsed": 217366
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To New Receiver With Same Delegatee",
-      "gasUsed": 74689
+      "gasUsed": 74667
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Same Delegatee",
-      "gasUsed": 84927
+      "gasUsed": 84905
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To Existing Receiver With Same Delegatee",
-      "gasUsed": 57908
+      "gasUsed": 57886
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Same Delegatee",
-      "gasUsed": 68134
+      "gasUsed": 68112
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To New Receiver With Custom Delegatee",
-      "gasUsed": 236288
+      "gasUsed": 236266
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Custom Delegatee",
-      "gasUsed": 251326
+      "gasUsed": 251304
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To Existing Receiver With Custom Delegatee",
-      "gasUsed": 202407
+      "gasUsed": 202385
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Custom Delegatee",
-      "gasUsed": 217445
+      "gasUsed": 217423
     },
     {
       "scenarioName": "Unstake Full Balance From The Default Delegatee",
-      "gasUsed": 227728
+      "gasUsed": 227706
     },
     {
       "scenarioName": "Unstake Partial Balance From The Default Delegatee",
-      "gasUsed": 237671
+      "gasUsed": 237649
     },
     {
       "scenarioName": "Unstake Full Balance From Unique Custom Delegatee",
-      "gasUsed": 313346
+      "gasUsed": 313328
     },
     {
       "scenarioName": "Unstake Partial Balance From Unique Custom Delegatee",
-      "gasUsed": 313876
+      "gasUsed": 313858
     },
     {
       "scenarioName": "Unstake Full Balance From a Non-Unique Custom Delegatee",
-      "gasUsed": 313346
+      "gasUsed": 313328
     },
     {
       "scenarioName": "Unstake Partial Balance From a Non-Unique Custom Delegatee",
-      "gasUsed": 313876
+      "gasUsed": 313858
     },
     {
       "scenarioName": "Unstake Full Balance From The Default Delegatee After Rewards",
-      "gasUsed": 232999
+      "gasUsed": 232977
     },
     {
       "scenarioName": "Unstake Partial Balance From The Default Delegatee After Rewards",
-      "gasUsed": 237823
+      "gasUsed": 237801
     },
     {
       "scenarioName": "Unstake Full Balance From Unique Custom Delegatee After Rewards",
-      "gasUsed": 366805
+      "gasUsed": 366783
     },
     {
       "scenarioName": "Unstake Partial Balance From Unique Custom Delegatee After Rewards",
-      "gasUsed": 366817
+      "gasUsed": 366795
     },
     {
       "scenarioName": "Unstake Full Balance From a Non-Unique Custom Delegatee After Rewards",
-      "gasUsed": 366817
+      "gasUsed": 366795
     },
     {
       "scenarioName": "Unstake Partial Balance From a Non-Unique Custom Delegatee After Rewards",
-      "gasUsed": 366817
+      "gasUsed": 366795
     },
     {
       "scenarioName": "Unstake Earned Rewards Only From The Default Delegatee After Rewards",
-      "gasUsed": 294324
+      "gasUsed": 294306
     },
     {
       "scenarioName": "Unstake Earned Rewards Only From Unique Custom Delegatee After Rewards",
-      "gasUsed": 294324
+      "gasUsed": 294306
     },
     {
       "scenarioName": "Updating from default deposit with nothing staked",
@@ -268,7 +268,7 @@
     },
     {
       "scenarioName": "Rescue funds sent to alias address",
-      "gasUsed": 61677
+      "gasUsed": 61655
     }
   ]
 }

--- a/test/gas-reports/lst-gas-report.json
+++ b/test/gas-reports/lst-gas-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": 1743447555,
+  "generatedAt": 1744648381,
   "reportName:": "lstGasReport",
   "results": [
     {
@@ -96,127 +96,127 @@
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Balance To a New Receiver With Default Delegatee",
-      "gasUsed": 56225
+      "gasUsed": 56203
     },
     {
       "scenarioName": "Sender With Default Delegatee Max Approves Caller To Transfer Balance To a New Receiver With Default Delegatee",
-      "gasUsed": 57891
+      "gasUsed": 57869
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Default Delegatee",
-      "gasUsed": 66144
+      "gasUsed": 66122
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 39444
+      "gasUsed": 39422
     },
     {
       "scenarioName": "Sender With Default Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 49363
+      "gasUsed": 49341
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To New Receiver With Default Delegatee",
-      "gasUsed": 206385
+      "gasUsed": 206363
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Default Delegatee",
-      "gasUsed": 216623
+      "gasUsed": 216601
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 189604
+      "gasUsed": 189582
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Default Delegatee",
-      "gasUsed": 199842
+      "gasUsed": 199820
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To New Receiver With Same Delegatee",
-      "gasUsed": 44837
+      "gasUsed": 44815
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Same Delegatee",
-      "gasUsed": 50275
+      "gasUsed": 50253
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To Existing Receiver With Same Delegatee",
-      "gasUsed": 45156
+      "gasUsed": 45134
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Same Delegatee",
-      "gasUsed": 50582
+      "gasUsed": 50560
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To New Receiver With Custom Delegatee",
-      "gasUsed": 206442
+      "gasUsed": 206420
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To New Receiver With Custom Delegatee",
-      "gasUsed": 216680
+      "gasUsed": 216658
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Balance To Existing Receiver With Custom Delegatee",
-      "gasUsed": 189661
+      "gasUsed": 189639
     },
     {
       "scenarioName": "Sender With Custom Delegatee Approves Caller To Transfer Partial Balance To Existing Receiver With Custom Delegatee",
-      "gasUsed": 199899
+      "gasUsed": 199877
     },
     {
       "scenarioName": "Unstake Full Balance From The Default Delegatee",
-      "gasUsed": 205309
+      "gasUsed": 205287
     },
     {
       "scenarioName": "Unstake Partial Balance From The Default Delegatee",
-      "gasUsed": 210439
+      "gasUsed": 210417
     },
     {
       "scenarioName": "Unstake Full Balance From Unique Custom Delegatee",
-      "gasUsed": 205613
+      "gasUsed": 205591
     },
     {
       "scenarioName": "Unstake Partial Balance From Unique Custom Delegatee",
-      "gasUsed": 210756
+      "gasUsed": 210734
     },
     {
       "scenarioName": "Unstake Full Balance From a Non-Unique Custom Delegatee",
-      "gasUsed": 210413
+      "gasUsed": 210391
     },
     {
       "scenarioName": "Unstake Partial Balance From a Non-Unique Custom Delegatee",
-      "gasUsed": 210756
+      "gasUsed": 210734
     },
     {
       "scenarioName": "Unstake Full Balance From The Default Delegatee After Rewards",
-      "gasUsed": 210528
+      "gasUsed": 210506
     },
     {
       "scenarioName": "Unstake Partial Balance From The Default Delegatee After Rewards",
-      "gasUsed": 210515
+      "gasUsed": 210493
     },
     {
       "scenarioName": "Unstake Full Balance From Unique Custom Delegatee After Rewards",
-      "gasUsed": 263753
+      "gasUsed": 263731
     },
     {
       "scenarioName": "Unstake Partial Balance From Unique Custom Delegatee After Rewards",
-      "gasUsed": 268553
+      "gasUsed": 268531
     },
     {
       "scenarioName": "Unstake Full Balance From a Non-Unique Custom Delegatee After Rewards",
-      "gasUsed": 268553
+      "gasUsed": 268531
     },
     {
       "scenarioName": "Unstake Partial Balance From a Non-Unique Custom Delegatee After Rewards",
-      "gasUsed": 268553
+      "gasUsed": 268531
     },
     {
       "scenarioName": "Unstake Earned Rewards Only From The Default Delegatee After Rewards",
-      "gasUsed": 210419
+      "gasUsed": 210397
     },
     {
       "scenarioName": "Unstake Earned Rewards Only From Unique Custom Delegatee After Rewards",
-      "gasUsed": 210419
+      "gasUsed": 210397
     },
     {
       "scenarioName": "Claim and distribute a reward",


### PR DESCRIPTION
* Properly mark the Fixed LST method's `delegates` method as view
* Add a `delegates` method to the Rebasing LST for IVotes compatibility
* Add a `delegateeForHolder` method to the Fixed LST for symmetry with the rebasing LST
* Add and improve natspec for all methods, including clarifying the purpose of the methods as being useful for backwards compatibility.

closes #88 