### PR TITLE
Modular Deploy Scripts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "lib/staker"]
 	path = lib/staker
 	url = https://github.com/withtally/staker
+	branch = feature/modular-deploy-scripts

--- a/src/script/DeployBase.sol
+++ b/src/script/DeployBase.sol
@@ -1,0 +1,74 @@
+//SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity ^0.8.23;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {Staker, IERC20} from "lib/staker/src/Staker.sol";
+import {GovLst} from "src/GovLst.sol";
+import {IEarningPowerCalculator} from "lib/staker/src/interfaces/IEarningPowerCalculator.sol";
+
+abstract contract DeployBase is Script {
+  address internal _autoDelegate;
+  GovLst public _rebasingLst;
+  address public deployer;
+
+  error DeployBase__InsufficientStakeToBurn();
+
+  function _fetchOrDeployAutoDelegate() internal virtual returns (address);
+
+  function _fetchOrDeployStakerStakingSystem()
+    internal
+    virtual
+    returns (IEarningPowerCalculator, Staker, address[] memory); /* _notifiers*/
+
+  function _govLstConfiguration(Staker _staker, address _autoDelegate)
+    internal
+    virtual
+    returns (GovLst.ConstructorParams memory);
+
+  function _deployGovLst(Staker _staker, address _autoDelegate) internal virtual returns (GovLst _govLst);
+
+  function run() public virtual returns (Staker, IEarningPowerCalculator, GovLst, address) {
+    uint256 deployerPrivateKey =
+      vm.envOr("DEPLOYER_PRIVATE_KEY", uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80));
+    deployer = vm.rememberKey(deployerPrivateKey);
+
+    _autoDelegate = _fetchOrDeployAutoDelegate();
+
+    (IEarningPowerCalculator _calculator, Staker _staker, address[] memory _notifiers) =
+      _fetchOrDeployStakerStakingSystem();
+    console2.log("Deployed Staker :", address(_staker));
+    console2.log("Deployed Earning Power Calculator :", address(_calculator));
+
+    address _admin = _staker.admin();
+    for (uint256 _i = 0; _i < _notifiers.length; _i++) {
+      vm.broadcast(_admin);
+      _staker.setRewardNotifier(_notifiers[_i], true);
+      console2.log("Deployed and Configured Notifier", _notifiers[_i]);
+    }
+
+    GovLst.ConstructorParams memory _lstConfig = _govLstConfiguration(_staker, _autoDelegate);
+
+    IERC20 stakeToken = _staker.STAKE_TOKEN();
+    uint256 deployerStakeBalance = stakeToken.balanceOf(deployer);
+    console2.log("Deployer's STAKE_TOKEN balance:", deployerStakeBalance);
+    console2.log("Required stakeToBurn for LST:", _lstConfig.stakeToBurn);
+
+    if (deployerStakeBalance < _lstConfig.stakeToBurn) {
+      revert DeployBase__InsufficientStakeToBurn();
+    }
+
+    uint256 _deployerNonce = vm.getNonce(deployer);
+    address _computedLstAddress = vm.computeCreateAddress(deployer, _deployerNonce + 1);
+
+    vm.broadcast(deployer);
+    stakeToken.approve(_computedLstAddress, _lstConfig.stakeToBurn);
+    console2.log("Approved", _computedLstAddress, _lstConfig.stakeToBurn);
+
+    _rebasingLst = _deployGovLst(_staker, _autoDelegate);
+    console2.log("Deployed Rebasing GovLst:", address(_rebasingLst));
+    console2.log("Deployed Fixed GovLst:", address(_rebasingLst.FIXED_LST()));
+
+    return (_staker, _calculator, _rebasingLst, _autoDelegate);
+  }
+}

--- a/src/script/DeployOverwhelmingSupportAutodelegate.sol
+++ b/src/script/DeployOverwhelmingSupportAutodelegate.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.23;
+
+import {DeployBase} from "./DeployBase.sol";
+
+abstract contract DeployOverwhelmingSupportAutodelegate is DeployBase {
+  struct AutoDelegateConfiguration {
+    address owner;
+    uint256 minVotingWindowTimepoints;
+    uint256 maxVotingWindowTimepoints;
+    uint256 initialVotingWindowTimepoints;
+    uint256 subQuorumBips;
+    uint256 supportThresholdBips;
+  }
+
+  function _autoDelegateConfiguration() public virtual returns (AutoDelegateConfiguration memory);
+}

--- a/test/fakes/FakeDeployBase.sol
+++ b/test/fakes/FakeDeployBase.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.23;
+
+import {Staker, IEarningPowerCalculator} from "lib/staker/src/Staker.sol";
+import {GovLst} from "src/GovLst.sol";
+import {GovLstHarness} from "stGOV-test/harnesses/GovLstHarness.sol";
+import {OverwhelmingSupportAutoDelegateOZGovernorTimestampModeMock} from
+  "stGOV-test/mocks/OverwhelmingSupportAutoDelegateOZGovernorTimestampModeMock.sol";
+import {DeployBase} from "src/script/DeployBase.sol";
+import {DeployBaseFake} from "lib/staker/test/fakes/DeployBaseFake.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {console2} from "forge-std/Test.sol";
+
+contract FakeDeployBase is DeployBase {
+  address public admin = makeAddr("Staker admin");
+  IERC20 public rewardToken;
+  IERC20 public stakeToken;
+  uint256 public initialVotingWindowTimepoints = 14_400; // copied from Rari
+  uint256 public subQuorumBips = 6600;
+  uint256 public supportThresholdBips = 9000;
+
+  constructor(IERC20 _rewardToken, IERC20 _stakeToken) {
+    rewardToken = _rewardToken;
+    stakeToken = _stakeToken;
+  }
+
+  function _fetchOrDeployAutoDelegate() internal virtual override returns (address) {
+    vm.broadcast(deployer);
+    OverwhelmingSupportAutoDelegateOZGovernorTimestampModeMock _autoDelegate = new OverwhelmingSupportAutoDelegateOZGovernorTimestampModeMock(
+      admin, initialVotingWindowTimepoints, subQuorumBips, supportThresholdBips
+    );
+    console2.log("Deployed Auto Delegate:", address(_autoDelegate));
+
+    return address(_autoDelegate);
+  }
+
+  function _fetchOrDeployStakerStakingSystem()
+    internal
+    virtual
+    override
+    returns (IEarningPowerCalculator _calculator, Staker _staker, address[] memory _notifiers)
+  {
+    DeployBaseFake _deployScript = new DeployBaseFake(rewardToken, stakeToken);
+    (_calculator, _staker, _notifiers) = _deployScript.run();
+  }
+
+  function _govLstConfiguration(Staker _staker, address _delegatee)
+    internal
+    virtual
+    override
+    returns (GovLst.ConstructorParams memory)
+  {
+    return GovLst.ConstructorParams({
+      fixedLstName: "Fixed LST",
+      fixedLstSymbol: "fLST",
+      rebasingLstName: "Rebasing LST",
+      rebasingLstSymbol: "rLST",
+      version: "1.0",
+      staker: _staker,
+      initialDefaultDelegatee: _delegatee,
+      initialOwner: admin,
+      initialPayoutAmount: 1000,
+      initialDelegateeGuardian: address(0),
+      stakeToBurn: 1e15,
+      minQualifyingEarningPowerBips: 1000
+    });
+  }
+
+  function _deployGovLst(Staker _staker, address _autoDelegate) internal virtual override returns (GovLst _govLst) {
+    GovLst.ConstructorParams memory _config = _govLstConfiguration(_staker, _autoDelegate);
+
+    vm.broadcast(deployer);
+    _govLst = new GovLstHarness(_config);
+    console2.log("Deployed rebalancing GovLst:", address(_govLst));
+  }
+
+  // Public wrapper for testing
+  function fetchOrDeployAutoDelegate() public returns (address) {
+    return _fetchOrDeployAutoDelegate();
+  }
+}

--- a/test/script/DeployBase.t.sol
+++ b/test/script/DeployBase.t.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+import {GovLst} from "src/GovLst.sol";
+import {Staker} from "staker/Staker.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IEarningPowerCalculator} from "staker/interfaces/IEarningPowerCalculator.sol";
+import {DeployBase} from "src/script/DeployBase.sol";
+import {ERC20VotesMock} from "lib/staker/test/mocks/MockERC20Votes.sol";
+import {FakeDeployBase} from "../fakes/FakeDeployBase.sol";
+import {MockERC20Token} from "../mocks/MockERC20Token.sol";
+
+contract DeployBaseTest is Test {
+  MockERC20Token public rewardToken;
+  ERC20VotesMock public stakeToken;
+  address public autoDelegate;
+  address public deployer;
+  uint256 public stakeToBurn;
+
+  function setUp() public {
+    rewardToken = new MockERC20Token();
+    vm.label(address(rewardToken), "Reward Token");
+
+    stakeToken = new ERC20VotesMock();
+    vm.label(address(stakeToken), "Stake Token");
+
+    autoDelegate = makeAddr("AutoDelegate");
+
+    uint256 deployerPrivateKey =
+      vm.envOr("DEPLOYER_PRIVATE_KEY", uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80));
+    deployer = vm.rememberKey(deployerPrivateKey);
+
+    stakeToBurn = 1e15;
+  }
+}
+
+contract Run is DeployBaseTest {
+  function test_GovLstSystemDeploy() public {
+    stakeToken.mint(deployer, stakeToBurn);
+
+    FakeDeployBase deployScript = new FakeDeployBase(IERC20(address(rewardToken)), IERC20(address(stakeToken)));
+
+    (Staker staker, IEarningPowerCalculator calculator, GovLst govLst, address deployedAutoDelegate) =
+      deployScript.run();
+
+    // Verify staker params
+    assertEq(address(staker.REWARD_TOKEN()), address(rewardToken));
+    assertEq(address(staker.STAKE_TOKEN()), address(stakeToken));
+    assertEq(address(staker.earningPowerCalculator()), address(calculator));
+    assertEq(staker.admin(), deployScript.admin());
+
+    // Verify GovLst deployment
+    assertEq(address(govLst), address(deployScript._rebasingLst()));
+    assertEq(address(govLst.defaultDelegatee()), deployedAutoDelegate);
+    assertEq(address(govLst.STAKER()), address(staker));
+    assertEq(govLst.name(), "Rebasing LST");
+    assertEq(govLst.symbol(), "rLST");
+    assertEq(govLst.owner(), deployScript.admin());
+    assertEq(address(govLst.FIXED_LST().LST().STAKER()), address(staker));
+    assertEq(address(govLst.FIXED_LST().STAKE_TOKEN()), address(stakeToken));
+  }
+
+  function test_RevertIf_InsufficientStakeToBurn(uint256 _insufficientBalance) public {
+    _insufficientBalance = bound(_insufficientBalance, 0, stakeToBurn - 1);
+    stakeToken.mint(deployer, _insufficientBalance);
+
+    FakeDeployBase deployScript = new FakeDeployBase(IERC20(address(rewardToken)), IERC20(address(stakeToken)));
+
+    vm.expectRevert(DeployBase.DeployBase__InsufficientStakeToBurn.selector);
+    deployScript.run();
+  }
+}


### PR DESCRIPTION
This is a compositional implementation of the `GovLst` deploy script.

It calls the `_fetchOrDeployStaker` deployer in the `run` function.

The `run` function is responsible for
- Fetching or deploying an `_autoDelegate` contract.
- Fetching or deploying the `Staker` system (Staker, EarningPowerCalculator, Notifiers) via `_fetchOrDeployStakerStakingSystem()`.
- Retrieving `GovLst.ConstructorParams` via `_govLstConfiguration()`, which is necessary to supply the `_computedLstAddress` with sufficient `stakeToBurn`.
- Performing a balance check for `stakeToBurn` against the deployer's stake token balance.
- Deploying the `GovLst` contract via `_deployGovLst()`.